### PR TITLE
Update Dockerfile to use production built files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# docker build --no-cache --platform=linux/amd64 -t transia/explorer-main -f explorer.dockerfile . --build-arg VUE_APP_WSS_ENDPOINT=ws://0.0.0.0:80 --build-arg PORT=4000
+# docker build --no-cache --platform=linux/amd64 -t transia/explorer-main -f Dockerfile . --build-arg VUE_APP_WSS_ENDPOINT=ws://localhost:6006 --build-arg PORT=4000
 # docker push transia/explorer-main
 FROM ubuntu:latest as cloner
 WORKDIR /app
@@ -11,18 +11,23 @@ RUN git clone https://github.com/Transia-RnD/XRPL-Technical-Explorer.git explore
 FROM node:16.17.0-alpine AS builder
 WORKDIR /app
 
-ARG PORT
-ENV PORT $PORT
-ARG VUE_APP_WSS_ENDPOINT
-ENV VUE_APP_WSS_ENDPOINT $VUE_APP_WSS_ENDPOINT
+RUN npm install -g @vue/cli@latest
 
 COPY --from=cloner /app/explorer /app
 
-RUN npm install -g @vue/cli@latest
 RUN npm install
+
+ARG VUE_APP_WSS_ENDPOINT
+ENV VUE_APP_WSS_ENDPOINT $VUE_APP_WSS_ENDPOINT
 RUN npm run build
 
-ENV HOST=0.0.0.0
-USER node
+FROM nginx:alpine as production
+WORKDIR /app
+
+COPY --from=builder /app/dist /usr/share/nginx/html
+ARG PORT
 EXPOSE $PORT
-CMD [ "npm", "run", "serve" ]
+
+RUN sed -i "s/listen  .*/listen ${PORT};/g" /etc/nginx/conf.d/default.conf
+
+# docker run --name technical-explorer -p 4000:4000 --rm transia/explorer-main


### PR DESCRIPTION
Changed from running `vue-cli-service serve` every time when starting container to run `vue-cli-service build` when building docker image.

This change shortens the time until explorer becomes available after container start.